### PR TITLE
interface to show/hide gui. Returns previous state

### DIFF
--- a/remote.lua
+++ b/remote.lua
@@ -12,18 +12,20 @@ function interface.reset_player(player_name_or_index)
     player_data.remote_viewer = nil
 end
 
-function interface.hide_expando(event)
-    if global.player_data[event.player_index].expandoed then
-        resmon.on_click.YARM_expando(event)
+function interface.hide_expando(player_name_or_index)
+    local player = game.get_player(player_name_or_index)
+    if global.player_data[player.index].expandoed then
+        resmon.on_click.YARM_expando({player_index=player.index})
         return true
     end
     
     return false
 end
 
-function interface.show_expando(event)
-    if not global.player_data[event.player_index].expandoed then
-        resmon.on_click.YARM_expando(event)
+function interface.show_expando(player_name_or_index)
+    local player = game.get_player(player_name_or_index)
+    if not global.player_data[player.index].expandoed then
+        resmon.on_click.YARM_expando({player_index=player.index})
         return false
     end
     

--- a/remote.lua
+++ b/remote.lua
@@ -12,5 +12,22 @@ function interface.reset_player(player_name_or_index)
     player_data.remote_viewer = nil
 end
 
+function interface.hide_expando(event)
+    if global.player_data[event.player_index].expandoed then
+        resmon.on_click.YARM_expando(event)
+        return true
+    end
+    
+    return false
+end
+
+function interface.show_expando(event)
+    if not global.player_data[event.player_index].expandoed then
+        resmon.on_click.YARM_expando(event)
+        return false
+    end
+    
+    return true
+end
 
 remote.add_interface("YARM", interface)


### PR DESCRIPTION
This allows other mods that add a (temporary) gui on the left to minimize YARM when their gui gets shown, when it gets closed they can restore YARMs previous state.
http://i.imgur.com/6sDjIOk.gif
Really only saves the player a few clicks, but i find it quite convenient.
