### PR TITLE
Add support for variable endless resource base values.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -5,4 +5,8 @@ if not resmon then resmon = {} end
 -- value:
 resmon.ticks_between_checks = 600
 
+-- An endless resource site (such as oil patches) will eventually reach some
+-- base production level. By default, this will be shown as 0% "full". Change this
+-- to 1000 for that base level of production to be shown as 100% "full".
+resmon.endless_resource_base = 0
 

--- a/resmon.lua
+++ b/resmon.lua
@@ -379,7 +379,7 @@ function resmon.count_deposits(site, update_cycle)
         -- calculate remaining permille as:
         -- how much of the minimum amount does the site have in excess to the site minimum amount?
         local site_minimum = #site.entities * site.minimum_resource_amount
-        site.remaining_permille = math.floor(site.amount * 1000 / site_minimum) - 1000
+        site.remaining_permille = math.floor(site.amount * 1000 / site_minimum) - 1000 + resmon.endless_resource_base
     end
 
     for i = #site.entities, 1, -1 do


### PR DESCRIPTION
I got tired of all my oil sites being bright red and visible when I collapse the list. This adds an option so the "base value" can be 100% instead. Or any other value you want, in theory!