### PR TITLE
Return to body after YARM collapse

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "{{MOD_NAME}}",
-  "version": "{{VERSION}}",
+  "name": "YARM",
+  "version": "0.7.205",
   "factorio_version": "0.15",
   "title": "YARM - Resource Monitor",
   "author": "Octav 'narc' Sandulescu, based on work by drs, jorgenRe, and L0771",

--- a/prototypes/prototypes.lua
+++ b/prototypes/prototypes.lua
@@ -3,7 +3,7 @@ data:extend(
     {
         type = "item",
         name = "resource-monitor",
-        icon = "__{{MOD_NAME}}__/graphics/resource-monitor.png",
+        icon = "__YARM__/graphics/resource-monitor.png",
         flags = {"goes-to-quickbar"},
         damage_radius = 5,
         subgroup = "tool",
@@ -15,7 +15,7 @@ data:extend(
     {
         type = "container",
         name = "resource-monitor",
-        icon = "__{{MOD_NAME}}__/graphics/resource-monitor.png",
+        icon = "__YARM__/graphics/resource-monitor.png",
         flags = {"placeable-neutral", "player-creation"},
         minable = {mining_time = 1, result = "resource-monitor"},
         max_health = 100,
@@ -27,7 +27,7 @@ data:extend(
         inventory_size = 1,
         picture =
         {
-            filename = "__{{MOD_NAME}}__/graphics/resource-monitor.png",
+            filename = "__YARM__/graphics/resource-monitor.png",
             priority = "extra-high",
             width = 32,
             height = 32,
@@ -47,7 +47,7 @@ data:extend(
     {
         type = "technology",
         name = "resource-monitoring",
-        icon = "__{{MOD_NAME}}__/graphics/yarm-tech.png",
+        icon = "__YARM__/graphics/yarm-tech.png",
         icon_size = 128,
         effects = {
             {
@@ -72,7 +72,7 @@ data:extend(
         type = "container",
         name = "rm_overlay",
         flags = {"placeable-neutral", "player-creation", "not-repairable"},
-        icon = "__{{MOD_NAME}}__/graphics/rm_Overlay.png",
+        icon = "__YARM__/graphics/rm_Overlay.png",
 
         max_health = 1,
         order = 'z[resource-monitor]',
@@ -84,7 +84,7 @@ data:extend(
         inventory_size = 1,
         picture =
         {
-            filename = "__{{MOD_NAME}}__/graphics/rm_Overlay.png",
+            filename = "__YARM__/graphics/rm_Overlay.png",
             priority = "extra-high",
             width = 32,
             height = 32,
@@ -102,7 +102,7 @@ data:extend(
 })
 
 local empty_animation = {
-    filename = "__{{MOD_NAME}}__/graphics/nil.png",
+    filename = "__YARM__/graphics/nil.png",
     priority = "medium",
     width = 0,
     height = 0,
@@ -173,7 +173,7 @@ local function button_graphics(xpos, ypos)
         left_monolith_border = 0,
 
         monolith_image = {
-            filename = "__{{MOD_NAME}}__/graphics/gui.png",
+            filename = "__YARM__/graphics/gui.png",
             priority = "extra-high-no-scale",
             width = 16,
             height = 16,

--- a/resmon.lua
+++ b/resmon.lua
@@ -725,6 +725,26 @@ function resmon.on_click.remove_site(event)
 end
 
 
+-- returning to our home body
+function resmon.return_body(event)
+    local player = game.players[event.player_index]
+    local player_data = global.player_data[event.player_index]
+	
+	if player_data.viewing_site ~=  nil then		
+		if player_data.real_character == nil or not player_data.real_character.valid then
+			player.print({"YARM-warn-no-return-possible"})
+			return
+		end
+
+		player.character = player_data.real_character
+		player_data.remote_viewer.destroy()
+
+		player_data.real_character = nil
+		player_data.remote_viewer = nil
+		player_data.viewing_site = nil
+	end
+end
+
 function resmon.on_click.goto_site(event)
     local site_name = string.sub(event.element.name, 1 + string.len("YARM_goto_site_"))
 
@@ -739,17 +759,7 @@ function resmon.on_click.goto_site(event)
 
     if player_data.viewing_site == site_name then
         -- returning to our home body
-        if player_data.real_character == nil or not player_data.real_character.valid then
-            player.print({"YARM-warn-no-return-possible"})
-            return
-        end
-
-        player.character = player_data.real_character
-        player_data.remote_viewer.destroy()
-
-        player_data.real_character = nil
-        player_data.remote_viewer = nil
-        player_data.viewing_site = nil
+        resmon.return_body(event)
     else
         -- stepping out to a remote viewer: first, be sure you remember your old body
         if not player_data.real_character or not player_data.real_character.valid then
@@ -938,6 +948,8 @@ function resmon.on_click.YARM_expando(event)
     if player_data.expandoed then
         player.gui.left.YARM_root.buttons.YARM_expando.style = "YARM_expando_long"
     else
+		-- when collapsing list, leave viewing site, return to body
+		resmon.return_body(event)
         player.gui.left.YARM_root.buttons.YARM_expando.style = "YARM_expando_short"
     end
 


### PR DESCRIPTION
When player collapses the YARM list, when they are viewing a site, the
view is automatically switched to the player's body.