### PR TITLE
expose data to other mods

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -48,4 +48,4 @@ script.on_event(defines.events.on_gui_click, function(event)
     if err then msg_all({"YARM-err-specific", "on_gui_click", err}) end
 end)
 
-on_updated = script.generate_event_name()
+on_site_updated = script.generate_event_name()

--- a/control.lua
+++ b/control.lua
@@ -47,3 +47,5 @@ script.on_event(defines.events.on_gui_click, function(event)
     local _, err = pcall(resmon.on_gui_click, event)
     if err then msg_all({"YARM-err-specific", "on_gui_click", err}) end
 end)
+
+on_updated = script.generate_event_name()

--- a/remote.lua
+++ b/remote.lua
@@ -32,8 +32,8 @@ function interface.show_expando(player_name_or_index)
     return true
 end
 
-function interface.get_on_updated_event_id()
-  return on_updated
+function interface.get_on_site_updated_event_id()
+  return on_site_updated
 end
 
 remote.add_interface("YARM", interface)

--- a/remote.lua
+++ b/remote.lua
@@ -18,7 +18,7 @@ function interface.hide_expando(player_name_or_index)
         resmon.on_click.YARM_expando({player_index=player.index})
         return true
     end
-    
+
     return false
 end
 
@@ -28,8 +28,12 @@ function interface.show_expando(player_name_or_index)
         resmon.on_click.YARM_expando({player_index=player.index})
         return false
     end
-    
+
     return true
+end
+
+function interface.get_on_updated_event_id()
+  return on_updated
 end
 
 remote.add_interface("YARM", interface)

--- a/resmon.lua
+++ b/resmon.lua
@@ -487,7 +487,8 @@ function resmon.finish_deposit_count(force, site)
       site_name          = site.name,
       amount             = site.amount,
       ore_per_minute     = site.ore_per_minute,
-      remaining_permille = site.remaining_permille
+      remaining_permille = site.remaining_permille,
+      ore_type           = site.ore_type,
     })
 end
 

--- a/resmon.lua
+++ b/resmon.lua
@@ -457,6 +457,7 @@ function resmon.tick_deposit_count(site)
 
 end
 
+
 function resmon.finish_deposit_count(site)
     site.iter_key = nil
     site.iter_fn = nil
@@ -984,14 +985,13 @@ end
 
 function resmon.update_forces(event)
     local update_cycle = event.tick % settings.global["YARM-ticks-between-checks"].value
-
     for _, force in pairs(game.forces) do
         local force_data = global.force_data[force.name]
 
         if not force_data then
             resmon.init_force(force)
         elseif force_data and force_data.ore_sites then
-            for site_name, site in pairs(force_data.ore_sites) do
+            for _, site in pairs(force_data.ore_sites) do
                 resmon.count_deposits(site, update_cycle)
             end
         end

--- a/resmon.lua
+++ b/resmon.lua
@@ -420,9 +420,9 @@ function resmon.is_endless_resource(ent_name, proto)
     return resmon.endless_resources[ent_name]
 end
 
-function resmon.count_deposits(force, site, update_cycle)
+function resmon.count_deposits(site, update_cycle)
     if site.iter_fn then
-        resmon.tick_deposit_count(force, site)
+        resmon.tick_deposit_count(site)
         return
     end
 
@@ -436,13 +436,13 @@ function resmon.count_deposits(force, site, update_cycle)
 end
 
 
-function resmon.tick_deposit_count(force, site)
+function resmon.tick_deposit_count(site)
     local key, pos
     key = site.iter_key
     for _ = 1, 100 do
         key, pos = site.iter_fn(site.iter_state, key)
         if key == nil then
-            resmon.finish_deposit_count(force, site)
+            resmon.finish_deposit_count(site)
             return
         end
         local ent = site.surface.find_entity(site.ore_type, pos)
@@ -457,7 +457,7 @@ function resmon.tick_deposit_count(force, site)
 
 end
 
-function resmon.finish_deposit_count(force, site)
+function resmon.finish_deposit_count(site)
     site.iter_key = nil
     site.iter_fn = nil
     site.iter_state = nil
@@ -483,7 +483,7 @@ function resmon.finish_deposit_count(force, site)
     end
 
     script.raise_event(on_site_updated, {
-      force_name         = force.name,
+      force_name         = site.force.name,
       site_name          = site.name,
       amount             = site.amount,
       ore_per_minute     = site.ore_per_minute,
@@ -992,7 +992,7 @@ function resmon.update_forces(event)
             resmon.init_force(force)
         elseif force_data and force_data.ore_sites then
             for site_name, site in pairs(force_data.ore_sites) do
-                resmon.count_deposits(force, site, update_cycle)
+                resmon.count_deposits(site, update_cycle)
             end
         end
     end

--- a/resmon.lua
+++ b/resmon.lua
@@ -976,17 +976,27 @@ end
 
 function resmon.update_forces(event)
     local update_cycle = event.tick % settings.global["YARM-ticks-between-checks"].value
+    local to_emit = {}
+
     for _, force in pairs(game.forces) do
         local force_data = global.force_data[force.name]
+        to_emit[force.name] = {}
 
         if not force_data then
             resmon.init_force(force)
         elseif force_data and force_data.ore_sites then
-            for _, site in pairs(force_data.ore_sites) do
+            for site_name, site in pairs(force_data.ore_sites) do
                 resmon.count_deposits(site, update_cycle)
+                to_emit[force.name][site_name] = {
+                  amount             = site.amount,
+                  ore_per_minute     = site.ore_per_minute,
+                  remaining_permille = site.remaining_permille
+                }
             end
         end
     end
+
+    script.raise_event(on_updated, to_emit)
 end
 
 function resmon.on_tick(event)


### PR DESCRIPTION
## summary

defines a custom event `on_site_updated` which is raised after calculating statistics for a site. site stats are sent with the event to allow consumption from other mods

## goals

- expose data to other mods without direct coupling
- include enough identifying information, such as force, to be compatible with single and multiplayer games
- raise event based on recalculation rate configured by users

## design

to expose the event to other mods, a new remote call `get_on_site_updated_event_id` is introduced. mods can use this to subscribe to the event:

```lua
script.on_event(remote.call("YARM", "get_on_site_updated_event_id"), function(site)

end)
```

the event is raised inside `finish_deposit_count` since that appears to be the closest location to when the data is updated. force was not available in that scope, and function signatures have been updated to allow it to be passed through from `update_forces`