### PR TITLE
Fixed critical griefing bug

### DIFF
--- a/resmon.lua
+++ b/resmon.lua
@@ -665,6 +665,9 @@ function resmon.on_click.YARM_rename_confirm(event)
 
     local old_name = player_data.renaming_site
     local new_name = player.gui.center.YARM_site_rename.new_name.text
+    
+    if string.len(new_name) > 50 then player.print('That name is too long, site names can be a maximum of 50 characters.') return end
+    --Sets the maximum site name to 50 Characters & prints an error to chat if over the limit
 
     local site = force_data.ore_sites[old_name]
     force_data.ore_sites[old_name] = nil


### PR DESCRIPTION
Added string length check to site rename confirmation, if over set limit it will print the error message stated to chat and won't allow the site name to be changed. This prevents a griefer from joining and changing a site name to a wall of text that pushes the rename button off the screen.