### PR TITLE
Switch to mod_gui as container frame

### DIFF
--- a/resmon.lua
+++ b/resmon.lua
@@ -1,5 +1,6 @@
 require "util"
 require "libs/array_pair"
+require "mod-gui"
 
 -- Sanity: site names aren't allowed to be longer than this, to prevent them
 -- kicking the buttons off the right edge of the screen
@@ -528,9 +529,10 @@ function resmon.update_ui(player)
     local player_data = global.player_data[player.index]
     local force_data = global.force_data[player.force.name]
 
-    local root = player.gui.left.YARM_root
+    local frame_flow = mod_gui.get_frame_flow(player)
+    local root = frame_flow.YARM_root
     if not root then
-        root = player.gui.left.add{type="frame",
+        root = frame_flow.add{type="frame",
                                    name="YARM_root",
                                    direction="horizontal",
                                    style="YARM_outer_frame_no_border"}


### PR DESCRIPTION
In https://mods.factorio.com/mod/Todo-List/discussion/5c7ba62ec3dad0000bfe86ed we discovered that having to many windows open on the screen breaks rendering of mods.

One option would be to use mod_gui as a container. mod_gui was developed by wube as standardized container for all mod windows (https://www.factorio.com/blog/post/fff-174). 

I hope that this switch prevents breaking rendering of other mods.

(What is missing is cleaning up existing UIs. I don't know enough about your mod to propose that at the moment :/