### PR TITLE
Add option to group resource list by ore type

### DIFF
--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -37,6 +37,7 @@ YARM-ticks-between-checks=Ticks between resource updates
 YARM-overlay-step=Overlay step
 YARM-warn-percent=Resource warning percent
 YARM-map-markers=Enable map markers
+YARM-group-by-ore=Group resource list by ore type
 YARM-debug-profiling=(Debug) Enable profiling output
 
 [mod-setting-description]
@@ -45,6 +46,7 @@ YARM-entities-per-tick=For resources that are being monitored, this controls how
 YARM-overlay-step=Adding huge resource patches can cause FPS drop with large overlays.  Changing the sparseness of the overlay will reduce the FPS drop by having less entities. Set to 1 for full coverage, 2 for 1/4, 3 for 1/9, etc.
 YARM-map-markers=Show markers on the map containing the site name and its current content, updating automatically. Note: after changing this setting, it may take a few seconds for the results to be visible!
 YARM-warn-percent=The percentage of remaining resources that will alert the player.
+YARM-group-by-ore=Sort resource list by ore type, then by percentage remaining.  If unchecked, the resource list is simply sorted by percentage remaining.
 YARM-debug-profiling=When enabled, outputs some information about tick timing to the player output and factorio-current.log.
 
 [YARM-tooltips]

--- a/resmon.lua
+++ b/resmon.lua
@@ -614,13 +614,30 @@ local function site_comparator(left, right)
     end
 end
 
+local function site_comparator_group_by_ore(left, right)
+    if left.ore_type ~= right.ore_type then
+        return left.ore_type < right.ore_type
+    elseif left.remaining_permille ~= right.remaining_permille then
+        return left.remaining_permille < right.remaining_permille
+    elseif left.added_at ~= right.added_at then
+        return left.added_at < right.added_at
+    else
+        return left.name < right.name
+    end
+end
 
-local function ascending_by_ratio(sites)
+
+local function ascending_by_ratio(sites, player)
+    local group_by_ore = player.mod_settings["YARM-group-by-ore"].value
     local ordered_sites = {}
     for _, site in pairs(sites) do
         table.insert(ordered_sites, site)
     end
-    table.sort(ordered_sites, site_comparator)
+    if group_by_ore then
+        table.sort(ordered_sites, site_comparator_group_by_ore)
+    else
+        table.sort(ordered_sites, site_comparator)
+    end
 
     local i = 0
     local n = #ordered_sites
@@ -680,7 +697,7 @@ function resmon.update_ui(player)
 
     local site_filter = resmon.filters[player_data.active_filter] or resmon.filters[FILTER_NONE]
     if force_data and force_data.ore_sites then
-        for site in ascending_by_ratio(force_data.ore_sites) do
+        for site in ascending_by_ratio(force_data.ore_sites, player) do
             if site_filter(site, player) then
                 resmon.print_single_site(site, player, sites_gui, player_data)
             end

--- a/settings.lua
+++ b/settings.lua
@@ -53,4 +53,11 @@ data:extend({
         minimum_value = 0,
         maximum_value = 100
     },
+	{
+        type = "bool-setting",
+        name = "YARM-group-by-ore",
+        setting_type = "runtime-per-user",
+        order = "b",
+        default_value = false,
+    },
 })


### PR DESCRIPTION
Adds a per-player settings checkbox to group resource list display by ore type.

As requested in #41 