### PR TITLE
Add sort options for ore-count and ETD

### DIFF
--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -11,6 +11,7 @@ YARM-etd-hour-fragment=__1__ h
 YARM-etd-minute-fragment=__1__ m
 YARM-etd-never=never
 YARM-etd-under-1m=<1 m
+YARM-etd-now=now
 
 YARM-site-rename-title=Rename '__1__'
 YARM-site-rename-confirm=Do it
@@ -52,6 +53,8 @@ YARM-debug-profiling=When enabled, outputs some information about tick timing to
 [string-mod-setting]
 YARM-order-by-percent-remaining=remaining percentage
 YARM-order-by-ore-type=ore type, then remaining percentage
+YARM-order-by-ore-count=ore count remaining
+YARM-order-by-etd=estimated time to depletion
 
 [YARM-tooltips]
 rename-site-named=Rename site '__1__'

--- a/settings.lua
+++ b/settings.lua
@@ -59,6 +59,6 @@ data:extend({
         setting_type = "runtime-per-user",
         order = "b",
         default_value = "percent-remaining",
-        allowed_values = { "percent-remaining", "ore-type" }
+        allowed_values = { "percent-remaining", "ore-type", "ore-count", "etd" }
     },
 })


### PR DESCRIPTION
**Important:** Existing saved games with YARM sites try to access etd_minutes before it's set (null ref), so I added a failsafe in time_to_deplete (line 874: "or -1").  With the failsafe, there are no errors, but some sites display "ETD: never" for a few seconds until initialization.  This may be better handled in the migration function.

**Changes in this pull request:**
Added sort option for ore count
Added sort option for ETD
Added custom ETD message: "now"
Moved ETD calculation to finish_deposit_count
ETD is now accessible as site.etd_minutes
etd_minutes value of -1 indicates ETD: Never (no miners depleting ore patch)
etd_minutes value of 0 indicates ETD: Now (already completely depleted)
ETD comparator sorts the list in proper order: Now .. X minutes .. Never (see comments in comparator function)

![Capture](https://user-images.githubusercontent.com/48728363/56422198-dc62dc80-626b-11e9-9578-293ec9f2a2ea.PNG)

**Note:** I did not write any special code for infinite resources, but I am looking into a more accurate calculation for ETD (really, estimated time to minimum yield).  I'll continue work on that in a separate branch soon.