### PR TITLE
Add item-icon to auto generated site name.

### DIFF
--- a/resmon.lua
+++ b/resmon.lua
@@ -950,7 +950,6 @@ function resmon.on_click.YARM_rename_confirm(event)
         -- boldly assume that there is an ore-icon in the supplied name.
         site.has_ore_icon_in_name = true
     else
-        -- boldly assume that there is an ore-icon in the supplied name.
         site.has_ore_icon_in_name = false
     end
 


### PR DESCRIPTION
Add item-icon to auto generated site name.
Don't add item-icon to chart tag if present in site name.
Boldly assume a site-name containing '[' has an item-icon.
Fixes #52