### PR TITLE
Conditionally add the surface name as a prefix to a new site

### DIFF
--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -41,6 +41,7 @@ YARM-overlay-step=Overlay step
 YARM-warn-percent=Resource warning percent
 YARM-map-markers=Enable map markers
 YARM-order-by=Order resource list by
+YARM-site-prefix-with-surface=Prefix the site name with the surface name
 YARM-debug-profiling=(Debug) Enable profiling output
 
 [mod-setting-description]
@@ -50,6 +51,7 @@ YARM-overlay-step=Adding huge resource patches can cause FPS drop with large ove
 YARM-map-markers=Show markers on the map containing the site name and its current content, updating automatically. Note: after changing this setting, it may take a few seconds for the results to be visible!
 YARM-warn-percent=The percentage of remaining resources that will alert the player.
 YARM-order-by=Change the display order of sites in the YARM list.
+YARM-site-prefix-with-surface=Prefix the surface name to the site name. Useful for maps with multiple surfaces.
 YARM-debug-profiling=When enabled, outputs some information about tick timing to the player output and factorio-current.log.
 
 [string-mod-setting]

--- a/resmon.lua
+++ b/resmon.lua
@@ -484,6 +484,9 @@ function resmon.finalize_site(player_index)
          instead of replacing the existing one) ]]
     if not site.is_site_expanding then
         site.name = string.format("%s %d", get_octant_name(site.center), util.distance({x=0, y=0}, site.center))
+        if settings.global["YARM-site-prefix-with-surface"].value then
+            site.name = string.format("%s %s", site.surface.name, site.name)
+        end
     end
 
     resmon.count_deposits(site, site.added_at % settings.global["YARM-ticks-between-checks"].value)

--- a/settings.lua
+++ b/settings.lua
@@ -37,6 +37,13 @@ data:extend({
     },
     {
         type = "bool-setting",
+        name = "YARM-site-prefix-with-surface",
+        setting_type = "runtime-global",
+        order = "d",
+        default_value = false
+    },
+    {
+        type = "bool-setting",
         name = "YARM-debug-profiling",
         setting_type = "runtime-global",
         order = "zz[debug]",


### PR DESCRIPTION
Related: https://github.com/narc0tiq/YARM/issues/121 - Unable to view sites on different surfaces

I added in a map setting which allows players to automatically prefix the site name with the name of the surface. I find that this feature is handy when using other mods like Space Exploration which use different surfaces for the planets. 

> I'm worried about potentially widening an already pretty wide GUI.

By default this setting is disabled to maintain the current behaviour and players can opt into this as they wish.

@narc0tiq can you take a look and let me know what you think? If you have any suggestions, let me know and Ill make the changes.