### PR TITLE
fix an ore per minute calculation error (fixes #118)

### DIFF
--- a/resmon.lua
+++ b/resmon.lua
@@ -640,14 +640,14 @@ function resmon.finish_deposit_count(site)
     site.iter_state = nil
 
     if site.last_ore_check then
-        local delta_ore_since_last_update = site.update_amount - site.amount
-        if delta_ore_since_last_update > 0 then           -- only store the amount and tick from last update if it actually changed
-            site.last_modified_tick = site.last_ore_check --
-            site.last_modified_amount = site.amount       --
-        end
         if not site.last_modified_amount then             -- make sure those two values have a default
             site.last_modified_amount = site.amount       --
             site.last_modified_tick = site.last_ore_check --
+        end
+        local delta_ore_since_last_update = site.last_modified_amount - site.amount
+        if delta_ore_since_last_update ~= 0 then           -- only store the amount and tick from last update if it actually changed
+            site.last_modified_tick = site.last_ore_check --
+            site.last_modified_amount = site.amount       --
         end
         local delta_ore_since_last_change = site.update_amount - site.last_modified_amount -- use final amount and tick to calculate
         local delta_ticks = game.tick - site.last_modified_tick                            --


### PR DESCRIPTION
Made an oversight when i originally wrote this, that kept YARM from recognizing "no change in ore amount" properly. This change fixes that.