### PR TITLE
Make fake ores optional, fix selection tool

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,18 +1,20 @@
 local ore_items = {}
 
-for name, proto in pairs(data.raw.resource) do
-    ore_items[#ore_items + 1] = {
-        type = 'item',
-        stack_size = 1,
-        hidden = true,
+if settings.startup["YARM-make-fake-ores"].value then
+    for name, proto in pairs(data.raw.resource) do
+        ore_items[#ore_items + 1] = {
+            type = 'item',
+            stack_size = 1,
+            hidden = true,
 
-        name = 'YARM-fake-' .. proto.name,
-        icon = proto.icon or nil,
-        icons = proto.icons or nil,
-        icon_size = proto.icon_size or nil,
+            name = 'YARM-fake-' .. proto.name,
+            icon = proto.icon or nil,
+            icons = proto.icons or nil,
+            icon_size = proto.icon_size or nil,
 
-        place_result = proto.name,
-    }
+            place_result = proto.name,
+        }
+    end
+
+    data:extend(ore_items)
 end
-
-data:extend(ore_items)

--- a/locale/en/base.cfg
+++ b/locale/en/base.cfg
@@ -54,6 +54,7 @@ YARM-grow-limit=Site growth limit
 YARM-adjust-over-percentage-sites=Adjust sites over 100%
 YARM-show-sites-summary=Show ore summary lines
 YARM-nominal-ups=Nominal UPS
+YARM-make-fake-ores=Define fake ore items
 
 [mod-setting-description]
 YARM-ticks-between-checks=When a resource site is being monitored, the amount of resources in it is only updated once every N game ticks (60 ticks = 1 second), based on this value. Increase to hopefully improve UPS, at the cost of needing longer to update a site's estimates.
@@ -71,6 +72,7 @@ YARM-productivity-parentheses-part-is=Change which amount (raw or adjusted for m
 YARM-grow-limit=Maximum distance from the original center that a site may grow when it is created. -1 = Unlimited growth. 0 = No growth. More than 0 = Limited growth.
 YARM-adjust-over-percentage-sites=When enabled sites will have their "initial amount" set to match the current amount, if the current amount of resources is more than the one noted initially. Can be used as a temporary fix or a permanent check.
 YARM-nominal-ups=The number of updates per second that YARM will assume when calculating ETD and mining speeds. 60 is the default, but if your game is consistently running below the default, adjust this value to your average UPS to get more accurate estimates and speeds.
+YARM-make-fake-ores=When enabled, YARM will create a phony item for each resource that, when placed, will create a mineable deposit of that resource. The items cannot be obtained. This is necessary for counting the number of ore entities while dragging the selection tool but may interact badly with other mods (e.g., AAI Programmable Structures) and is thus off by default.
 
 [string-mod-setting]
 YARM-order-by-percent-remaining=remaining percentage

--- a/prototypes/prototypes.lua
+++ b/prototypes/prototypes.lua
@@ -27,14 +27,13 @@ data:extend(
             icon_size = 32,
             flags = { 'only-in-cursor', 'spawnable' },
             stack_size = 1,
-            stackable = false,
-            entity_filter_mode = 'whitelist',
-            entity_type_filters = { 'resource' },
             hidden = true,
             select = {
                 border_color = { g = 1 },
                 cursor_box_type = 'copy',
                 mode = 'any-entity',
+                entity_filter_mode = 'whitelist',
+                entity_type_filters = { 'resource' },
             },
             alt_select = {
                 border_color = { g = 1, b = 1 },

--- a/settings.lua
+++ b/settings.lua
@@ -132,4 +132,10 @@ data:extend({
         order = "d",
         default_value = true
     },
+    {
+        type = "bool-setting",
+        name = "YARM-make-fake-ores",
+        setting_type = "startup",
+        default_value = false
+    }
 })


### PR DESCRIPTION
The fake ore items are reported to interact badly with AAI Programmable Structures but only exist for a vanity reason (counting resource entities while dragging). They are now locked behind a setting, off by default.

Additionally, the selection tool filter modes have moved into a sub-object and were thus not actually applying: only resources *should* be actually selected by the YARM tool.

Closes #124 for the default case, with a hint for players that enabling the setting has a known bad interaction with AAI.